### PR TITLE
Fix for Debian based distros

### DIFF
--- a/lib/core.sh
+++ b/lib/core.sh
@@ -45,9 +45,11 @@ shootProfile(){
 				REV=`cat /etc/mandrake-release | sed s/.*release\ // | sed s/\ .*//`
 			elif [ -f /etc/debian_version ] ; then
 				DistroBasedOn='Debian'
-				DIST=`cat /etc/lsb-release | grep '^DISTRIB_ID' | awk -F=  '{ print $2 }'`
-				PSUEDONAME=`cat /etc/lsb-release | grep '^DISTRIB_CODENAME' | awk -F=  '{ print $2 }'`
-				REV=`cat /etc/lsb-release | grep '^DISTRIB_RELEASE' | awk -F=  '{ print $2 }'`
+				if [ -f /etc/lsb-release ] ; then
+			        	DIST=`cat /etc/lsb-release | grep '^DISTRIB_ID' | awk -F=  '{ print $2 }'`
+			                PSUEDONAME=`cat /etc/lsb-release | grep '^DISTRIB_CODENAME' | awk -F=  '{ print $2 }'`
+			                REV=`cat /etc/lsb-release | grep '^DISTRIB_RELEASE' | awk -F=  '{ print $2 }'`
+            			fi
 			fi
 			if [ -f /etc/UnitedLinux-release ] ; then
 				DIST="${DIST}[`cat /etc/UnitedLinux-release | tr "\n" ' ' | sed s/VERSION.*//`]"


### PR DESCRIPTION
Check to see if /etc/lsb-release exists to avoid:
cat: can't open '/etc/lsb-release': No such file or directory
cat: can't open '/etc/lsb-release': No such file or directory
cat: can't open '/etc/lsb-release': No such file or directory
